### PR TITLE
net45-framwork target added

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,4 @@ script:
   - dotnet restore
   - dotnet build ./Lib -f netstandard1.1 -c Realease
   - dotnet build ./App -c Realease
-  - dotnet build ./Test -c Realease
   - dotnet test ./Tests/Tests.csproj -c Release


### PR DESCRIPTION
.Net 4.5 framwork target added in the project config to avoid the netstadard dependencies pollution when installing this package to a classic .NET 4.5 that still uses packages.config